### PR TITLE
Auto resize

### DIFF
--- a/widgets.py
+++ b/widgets.py
@@ -89,7 +89,8 @@ class SelfWrappingHyperlinkLabel(HyperlinkLabel):
         "Init."
 
         HyperlinkLabel.__init__(self, *a, **kw)
-        self.bind('<Configure>', self.__configure_event)
+        self.frame=a[0]
+        self.frame.bind('<Configure>', self.__configure_event)
 
     def __configure_event(self, event):
         "Handle resizing."


### PR DESCRIPTION
I tried using this SelfWrappingHyperlinkLabel in one of my own projects and found that it wasn't resizing properly. It was always wrapping too short. This might only be apparent if you are using lots of plugins.  So I modified to bind to the parent frame <Configure> event and now it seems to work fine.