### PR TITLE
Stop being a "package plugin"; defend ourselves

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,0 @@
-"""
-The Hutton Helper. For the Mug!
-
-This file turns the Helper into a "package plugin".
-"""
-
-__version__ = '2.1.11'

--- a/forward.py
+++ b/forward.py
@@ -2,7 +2,7 @@
 Broadcasts to the Hutton Helper web site.
 """
 
-from __init__ import __version__ as HH_VERSION
+from version import HH_VERSION
 
 import json
 import zlib

--- a/load.py
+++ b/load.py
@@ -1,6 +1,6 @@
 "The Hutton Helper. For the Mug!"
 
-from __init__ import __version__ as HH_VERSION
+from version import HH_VERSION
 
 import json
 import os
@@ -20,20 +20,30 @@ import tkMessageBox
 
 import requests # still here for CG code
 
-# Internal plugins and utilities:
-import cgt
-import exploration
-import forward
-import influence
-import local
-import news
-import plugin as plugin_module
-import progress
-import shopping
-import toolbar
-import updater
-import widgets
-import xmit
+try:
+    HERE = os.path.dirname(__file__)
+    sys.path.insert(0, HERE)
+
+    # We import the rest of the Hutton Helper together in this block while
+    # we've altered sys.path so we don't inhale files from EDMC "package"
+    # plugins by accident. https://git.io/fAQkf#python-package-plugins
+
+    import cgt
+    import exploration
+    import forward
+    import influence
+    import local
+    import news
+    import plugin as plugin_module
+    import progress
+    import shopping
+    import toolbar
+    import updater
+    import widgets
+    import xmit
+
+finally:
+    del sys.path[0]
 
 this = sys.modules[__name__]  # pylint: disable=C0103
 this.msg = ""

--- a/local.py
+++ b/local.py
@@ -2,7 +2,7 @@
 Treats LOCAL as if it's a command line.
 """
 
-from __init__ import __version__ as HH_VERSION
+from version import HH_VERSION
 
 import json
 import zlib

--- a/pack.py
+++ b/pack.py
@@ -2,7 +2,7 @@
 Code to pack updates into ZIP files.
 """
 
-from __init__ import __version__ as HH_VERSION
+from version import HH_VERSION
 
 import hashlib
 import json

--- a/updater.py
+++ b/updater.py
@@ -2,7 +2,7 @@
 Update mechanism.
 """
 
-from __init__ import __version__ as HH_VERSION
+from version import HH_VERSION
 
 import collections
 import ConfigParser

--- a/version.py
+++ b/version.py
@@ -1,0 +1,5 @@
+"""
+Supplies a version number.
+"""
+
+HH_VERSION = '2.1.12'


### PR DESCRIPTION
We don't need to supply code to other EDMC plugins, so we don't need to
be a [package plugin](https://git.io/fAQkf#python-package-plugins):

> Other plugins can access features in a Package Plugin by importing
> the package by name in the usual way

As pointed out by @NoFoolLikeOne in #45, this creates the opportunity
for conflicts. Instead of getting their `widgets.py`, they might get
ours, or vice versa. It's obvious once you peek at EDMC:

```python
sys.path.append(os.path.join(config.plugin_dir, name))
```

Oops.

In this commit, we remove `__init__.py` so we're not added to
`sys.path` for other plugins to import by accident. That's not enough to
stop us from inhaling `widgets.py` from some other plugin, though, so we
also insert our own directory at the front of `sys.path` in `load.py`
while we `import` the rest of the Helper.