### PR TITLE
GET explosystem and besthuttonrun #55

### DIFF
--- a/exploration.py
+++ b/exploration.py
@@ -20,10 +20,10 @@ CFG_SHOW_EXPLORATION = 'ShowExploValue'
 class ExplorationPlugin(plugin.HuttonHelperPlugin):
     "Tracks exploration data gathering."
 
-    def __init__(self, config):
+    def __init__(self, helper):
         "Initialise the ``ExplorationPlugin``."
 
-        plugin.HuttonHelperPlugin.__init__(self, config)
+        plugin.HuttonHelperPlugin.__init__(self, helper)
         self.frame = None
         self.cmdr = None
         self.credits = None

--- a/influence.py
+++ b/influence.py
@@ -24,10 +24,10 @@ FACTIONS = set([
 class InfluencePlugin(plugin.HuttonHelperPlugin):
     "Tracks mission shopping lists."
 
-    def __init__(self, config):
+    def __init__(self, helper):
         "Initialise the ``InfluencePlugin``."
 
-        plugin.HuttonHelperPlugin.__init__(self, config)
+        plugin.HuttonHelperPlugin.__init__(self, helper)
         self.label = None
         self.in_faction_space = False
 

--- a/local.py
+++ b/local.py
@@ -58,6 +58,7 @@ class CommandPlugin(plugin.HuttonHelperPlugin):
     def __init__(self, helper):
         "Initialise the ``CommandPlugin``."
 
+        plugin.HuttonHelperPlugin.__init__(self, helper)
         self.commands = set(self.xmit_paths.keys()) | set(self.status_formats.keys())
 
     def journal_entry(self, cmdr, is_beta, system, station, entry, state):
@@ -78,10 +79,10 @@ class CommandPlugin(plugin.HuttonHelperPlugin):
 
                 # Send the event if required, getting json_data back:
                 json_data = None
-                command_xmit_path = self.xmit_paths.get(command)
-                if command_xmit_path:
-                    command_xmit_path = command_xmit_path.format(cmdr=cmdr, system=system)
-                    if '{cmdr}' in command_xmit_path: # FILTHY hack to figure out if it's a 'get'
+                command_xmit_path_format = self.xmit_paths.get(command)
+                if command_xmit_path_format:
+                    command_xmit_path = command_xmit_path_format.format(cmdr=cmdr, system=system)
+                    if '{cmdr}' in command_xmit_path_format: # FILTHY hack to figure out if it's a 'get'
                         json_data = xmit.get(command_xmit_path)
                     else:
                         json_data = xmit.post(command_xmit_path, data=transmit_json, headers=xmit.COMPRESSED_OCTET_STREAM)

--- a/shopping.py
+++ b/shopping.py
@@ -169,10 +169,10 @@ def extract_commodity(entry):
 class ShoppingListPlugin(plugin.HuttonHelperPlugin):
     "Tracks mission shopping lists."
 
-    def __init__(self, config):
+    def __init__(self, helper):
         "Initialise the ``ShoppingListPlugin``."
 
-        plugin.HuttonHelperPlugin.__init__(self, config)
+        plugin.HuttonHelperPlugin.__init__(self, helper)
         self.table_frame = None
         self.missions = []
         self.cargo = {}

--- a/updater.py
+++ b/updater.py
@@ -129,10 +129,10 @@ def update(zipfile_url, digest):
 class UpdatePlugin(plugin.HuttonHelperPlugin):
     "An update plugin."
 
-    def __init__(self, config):
+    def __init__(self, helper):
         "Initialise the ``UpdatePlugin``."
 
-        plugin.HuttonHelperPlugin.__init__(self, config)
+        plugin.HuttonHelperPlugin.__init__(self, helper)
 
         self.remote_version = None
         self.zipfile_url = None


### PR DESCRIPTION
Also, fixes a problem which would have blocked all attempts to set the status message.

Also, drags all `__init__` methods for `HuttonHelperPlugin` subclasses to correctly call the first argument `helper`, not `config`.